### PR TITLE
fix: restrict Python version for spaCy compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "kokoro-fastapi"
 version = "0.3.0"
 description = "FastAPI TTS Service"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 dependencies = [
     # Core dependencies
     "fastapi==0.115.6",


### PR DESCRIPTION
https://github.com/fileogg10/Kokoro-FastAPI/compare/master...fileogg10:Kokoro-FastAPI:patch-1